### PR TITLE
Add optimization settings to the REST API

### DIFF
--- a/src/main/java/com/sap/charging/realTime/StrategyAlgorithmic.java
+++ b/src/main/java/com/sap/charging/realTime/StrategyAlgorithmic.java
@@ -119,7 +119,6 @@ public class StrategyAlgorithmic extends Strategy {
 		if (highestObjective == objectiveFairShare || highestObjective == null) {
 			return TimeslotSortingCriteria.INDEX;
 		}
-			
 		
 		throw new RuntimeException("Recheck objective weights");
 	}
@@ -789,11 +788,10 @@ public class StrategyAlgorithmic extends Strategy {
 				log(2, "No expected departure time passed in, setting to expectedDepartureTimeSeconds=" + expectedDepartureTimeSeconds); 
 			}
 			
-			
 			// Always reoptimize
 			if (car.isFullyCharged() == false) {
 				scheduler.fillChargingPlanToMinSoC(state, currentK, state.energyPriceHistory.getNTimeslots(), car, chargingStation, state.currentTimeSeconds);
-				scheduler.fillChargingPlanToFull(state, currentK, state.energyPriceHistory.getNTimeslots(), car, chargingStation, state.currentTimeSeconds);
+				scheduler.fillChargingPlanByCost(state, currentK, state.energyPriceHistory.getNTimeslots(), car, chargingStation, state.currentTimeSeconds);
 			}
 			
 			// Always reoptimize for nonlinear processes (frees up more infrastructure capacity):

--- a/src/main/java/com/sap/charging/server/EmobilitySmartChargingApplication.java
+++ b/src/main/java/com/sap/charging/server/EmobilitySmartChargingApplication.java
@@ -6,8 +6,6 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 @SpringBootApplication
 public class EmobilitySmartChargingApplication {
 
-	public static int verbosity;
-	
 	public static void main(String[] args) {
 		SpringApplication.run(EmobilitySmartChargingApplication.class, args);
 	}

--- a/src/main/java/com/sap/charging/server/api/v1/OptimizeChargingProfilesController.java
+++ b/src/main/java/com/sap/charging/server/api/v1/OptimizeChargingProfilesController.java
@@ -1,4 +1,4 @@
-package com.sap.charging.server.api.v1; 
+package com.sap.charging.server.api.v1;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -25,63 +25,59 @@ import io.swagger.annotations.ApiParam;
 @Api(value = "emobility-smart-charging REST API")
 public class OptimizeChargingProfilesController implements Loggable {
 
-	@Override
-	public int getVerbosity() {
-		return Simulation.verbosity;
-	}
-	
-	public StrategyAlgorithmic buildStrategy(OptimizerSettings settings) {
-		StrategyAlgorithmic strategy = new StrategyAlgorithmic(CarDepartureForecast.getDefaultCarDepartureForecast()); 
-    	strategy.objectiveFairShare.setWeight(settings.getWeightObjectiveFairShare());
-    	strategy.objectiveEnergyCosts.setWeight(settings.getWeightObjectiveEnergyCosts());
-    	strategy.objectivePeakShaving.setWeight(settings.getWeightObjectivePeakShaving());
-    	strategy.objectiveLoadImbalance.setWeight(settings.getWeightObjectiveLoadImbalance());
-    	strategy.setReoptimizeOnStillAvailableAfterExpectedDepartureTimeslot(true);
-    	strategy.setRescheduleCarsWith0A(false);
-    	return strategy; 
-	}
+    @Override
+    public int getVerbosity() {
+        return Simulation.verbosity;
+    }
 
-	@CrossOrigin(origins = "*")	
-	@ApiOperation(value = "Optimize Charging Profiles")
-    @PostMapping(path="/api/v1/OptimizeChargingProfiles", produces=MediaType.APPLICATION_JSON_VALUE)
+    public StrategyAlgorithmic buildStrategy(OptimizerSettings settings) {
+        StrategyAlgorithmic strategy = new StrategyAlgorithmic(CarDepartureForecast.getDefaultCarDepartureForecast());
+        strategy.objectiveFairShare.setWeight(settings.getWeightObjectiveFairShare());
+        strategy.objectiveEnergyCosts.setWeight(settings.getWeightObjectiveEnergyCosts());
+        strategy.objectivePeakShaving.setWeight(settings.getWeightObjectivePeakShaving());
+        strategy.objectiveLoadImbalance.setWeight(settings.getWeightObjectiveLoadImbalance());
+        strategy.setReoptimizeOnStillAvailableAfterExpectedDepartureTimeslot(true);
+        strategy.setRescheduleCarsWith0A(false);
+        return strategy;
+    }
+
+    @CrossOrigin(origins = "*")
+    @ApiOperation(value = "Optimize Charging Profiles")
+    @PostMapping(path = "/api/v1/OptimizeChargingProfiles", produces = MediaType.APPLICATION_JSON_VALUE)
     @ResponseBody
     public ResponseEntity<Object> optimizeChargingProfiles(@ApiParam @RequestBody OptimizeChargingProfilesRequest request) {
-    	
-    	Simulation.verbosity = request.verbosity;
-    	    	
-    	log(1, "Received /api/v1/OptimizeChargingProfiles with body: " + request.toString());
-    	log(1, "Using optimizer settings: " + request.optimizerSettings.toString());
-    	
-    	// Request values
-    	Object response = null; 
-    	HttpStatus httpStatus = HttpStatus.ACCEPTED; 
-    	try {
-        	State state = request.state.toState(); 
-    		Event event = request.event.toEvent(state); 
-        	
-        	// React to events
-        	StrategyAlgorithmic strategy = buildStrategy(request.optimizerSettings);
-        	log(1, "Optimizer's sorting criteria (objective for cars above min SoC): " + strategy.getSortingCriteriaByObjective()); 
-        	
-        	strategy.react(state, event); 
-        	
-        	// Create response
-        	response = new OptimizeChargingProfilesResponse(state.cars);
-    	}
-    	catch (Exception e) {
-    		System.err.println(e.getClass().getName()); 
-    		System.err.println(e.getMessage()); 
-    		response = new ErrorResponse(e); 
-    		httpStatus = HttpStatus.INTERNAL_SERVER_ERROR; 
-    		e.printStackTrace();
-    	}
-    	
-    	return new ResponseEntity<>(response, httpStatus); 
+
+        Simulation.verbosity = request.verbosity;
+
+        log(1, "Received /api/v1/OptimizeChargingProfiles with body: " + request.toString());
+        log(1, "Using optimizer settings: " + request.optimizerSettings.toString());
+
+        // Request values
+        Object response = null;
+        HttpStatus httpStatus = HttpStatus.ACCEPTED;
+        try {
+            State state = request.state.toState();
+            Event event = request.event.toEvent(state);
+
+            // React to events
+            StrategyAlgorithmic strategy = buildStrategy(request.optimizerSettings);
+            log(1, "Optimizer's sorting criteria (objective for cars above min SoC): " + strategy.getSortingCriteriaByObjective());
+
+            strategy.react(state, event);
+
+            // Create response
+            response = new OptimizeChargingProfilesResponse(state.cars);
+        } catch (Exception e) {
+            System.err.println(e.getClass().getName());
+            System.err.println(e.getMessage());
+            response = new ErrorResponse(e);
+            httpStatus = HttpStatus.INTERNAL_SERVER_ERROR;
+            e.printStackTrace();
+        }
+
+        return new ResponseEntity<>(response, httpStatus);
     }
 
 }
-
-
-
 
 

--- a/src/main/java/com/sap/charging/server/api/v1/OptimizeChargingProfilesController.java
+++ b/src/main/java/com/sap/charging/server/api/v1/OptimizeChargingProfilesController.java
@@ -12,6 +12,7 @@ import org.springframework.web.bind.annotation.RestController;
 import com.sap.charging.realTime.State;
 import com.sap.charging.realTime.StrategyAlgorithmic;
 import com.sap.charging.realTime.model.forecasting.departure.CarDepartureForecast;
+import com.sap.charging.server.api.v1.store.OptimizerSettings;
 import com.sap.charging.sim.Simulation;
 import com.sap.charging.sim.event.Event;
 import com.sap.charging.util.Loggable;
@@ -28,41 +29,46 @@ public class OptimizeChargingProfilesController implements Loggable {
 	public int getVerbosity() {
 		return Simulation.verbosity;
 	}
+	
+	public StrategyAlgorithmic buildStrategy(OptimizerSettings settings) {
+		StrategyAlgorithmic strategy = new StrategyAlgorithmic(CarDepartureForecast.getDefaultCarDepartureForecast()); 
+    	strategy.objectiveFairShare.setWeight(settings.getWeightObjectiveFairShare());
+    	strategy.objectiveEnergyCosts.setWeight(settings.getWeightObjectiveEnergyCosts());
+    	strategy.objectivePeakShaving.setWeight(settings.getWeightObjectivePeakShaving());
+    	strategy.objectiveLoadImbalance.setWeight(settings.getWeightObjectiveLoadImbalance());
+    	strategy.setReoptimizeOnStillAvailableAfterExpectedDepartureTimeslot(true);
+    	strategy.setRescheduleCarsWith0A(false);
+    	return strategy; 
+	}
 
 	@CrossOrigin(origins = "*")	
 	@ApiOperation(value = "Optimize Charging Profiles")
     @PostMapping(path="/api/v1/OptimizeChargingProfiles", produces=MediaType.APPLICATION_JSON_VALUE)
     @ResponseBody
-    public ResponseEntity<Object> optimizeChargingProfiles( @ApiParam @RequestBody OptimizeChargingProfilesRequest request) {
+    public ResponseEntity<Object> optimizeChargingProfiles(@ApiParam @RequestBody OptimizeChargingProfilesRequest request) {
     	
     	Simulation.verbosity = request.verbosity;
     	    	
-    	//ObjectMapper mapper = new ObjectMapper(); // jackson's objectmapper
-    	    	
     	log(1, "Received /api/v1/OptimizeChargingProfiles with body: " + request.toString());
+    	log(1, "Using optimizer settings: " + request.optimizerSettings.toString());
     	
     	// Request values
     	Object response = null; 
     	HttpStatus httpStatus = HttpStatus.ACCEPTED; 
     	try {
-    		//OptimizeChargingProfilesRequest request = mapper.convertValue(payload, OptimizeChargingProfilesRequest.class);
         	State state = request.state.toState(); 
     		Event event = request.event.toEvent(state); 
         	
         	// React to events
-        	StrategyAlgorithmic strategy = new StrategyAlgorithmic(CarDepartureForecast.getDefaultCarDepartureForecast()); 
-        	strategy.objectiveEnergyCosts.setWeight(0);
-        	strategy.objectiveFairShare.setWeight(1);
-        	strategy.setReoptimizeOnStillAvailableAfterExpectedDepartureTimeslot(true);
-        	strategy.setRescheduleCarsWith0A(false);
-        	strategy.react(state, event); 
+        	StrategyAlgorithmic strategy = buildStrategy(request.optimizerSettings);
+        	log(1, "Optimizer's sorting criteria (objective for cars above min SoC): " + strategy.getSortingCriteriaByObjective()); 
         	
+        	strategy.react(state, event); 
         	
         	// Create response
         	response = new OptimizeChargingProfilesResponse(state.cars);
     	}
     	catch (Exception e) {
-    		//e.printStackTrace();
     		System.err.println(e.getClass().getName()); 
     		System.err.println(e.getMessage()); 
     		response = new ErrorResponse(e); 
@@ -70,9 +76,6 @@ public class OptimizeChargingProfilesController implements Loggable {
     		e.printStackTrace();
     	}
     	
-    	
-    	
-    	//String result = "End point working! Loaded " + state.cars.size() + " cars and " + state.nChargingStations + " charging stations. Charging profile produced: " + Arrays.toString(state.getCar(0).getCurrentPlan()); 
     	return new ResponseEntity<>(response, httpStatus); 
     }
 

--- a/src/main/java/com/sap/charging/server/api/v1/OptimizeChargingProfilesRequest.java
+++ b/src/main/java/com/sap/charging/server/api/v1/OptimizeChargingProfilesRequest.java
@@ -3,6 +3,7 @@ package com.sap.charging.server.api.v1;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.sap.charging.server.api.v1.store.EventStore;
+import com.sap.charging.server.api.v1.store.OptimizerSettings;
 import com.sap.charging.server.api.v1.store.StateStore;
 
 public class OptimizeChargingProfilesRequest {
@@ -10,11 +11,13 @@ public class OptimizeChargingProfilesRequest {
 	public StateStore state; 
 	public EventStore event; 
 	public Integer verbosity;
+	public OptimizerSettings optimizerSettings; 
 	
 	@JsonCreator
 	public OptimizeChargingProfilesRequest(
 			@JsonProperty(value="state", required=true) StateStore state,
 			@JsonProperty(value="event", required=true) EventStore event,
+			@JsonProperty(value="optimizerSettings") OptimizerSettings optimizerSettings,
 			@JsonProperty(value="verbosity") Integer verbosity
 			) {
 		this.state = state; 
@@ -24,7 +27,11 @@ public class OptimizeChargingProfilesRequest {
 		} else {
 			this.verbosity = 3;
 		}
+		if (optimizerSettings != null) {
+			this.optimizerSettings = optimizerSettings;
+		} else {
+			this.optimizerSettings = OptimizerSettings.getDefaultOptimizerSettings();
+		}
 	}
-	
 	
 }

--- a/src/main/java/com/sap/charging/server/api/v1/store/OptimizerSettings.java
+++ b/src/main/java/com/sap/charging/server/api/v1/store/OptimizerSettings.java
@@ -17,6 +17,12 @@ public class OptimizerSettings {
         @JsonProperty("weightObjectivePeakShaving") double weightObjectivePeakShaving,
         @JsonProperty("weightObjectiveEnergyCosts") double weightObjectiveEnergyCosts,
         @JsonProperty("weightObjectiveLoadImbalance") double weightObjectiveLoadImbalance) {
+
+        if (weightObjectiveFairShare < 0 || weightObjectivePeakShaving < 0 || weightObjectiveEnergyCosts < 0
+            || weightObjectiveLoadImbalance < 0) {
+            throw new IllegalArgumentException("Optimizer objective weight settings should be >= 0");
+        }
+
         this.weightObjectiveFairShare = weightObjectiveFairShare;
         this.weightObjectivePeakShaving = weightObjectivePeakShaving;
         this.weightObjectiveEnergyCosts = weightObjectiveEnergyCosts;

--- a/src/main/java/com/sap/charging/server/api/v1/store/OptimizerSettings.java
+++ b/src/main/java/com/sap/charging/server/api/v1/store/OptimizerSettings.java
@@ -1,0 +1,79 @@
+package com.sap.charging.server.api.v1.store;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class OptimizerSettings {
+	
+	private double weightObjectiveFairShare;
+	private double weightObjectivePeakShaving;
+	private double weightObjectiveEnergyCosts;
+	private double weightObjectiveLoadImbalance;
+	
+	public OptimizerSettings() {}
+	
+	@JsonCreator
+	public OptimizerSettings(@JsonProperty("weightObjectiveFairShare") double weightObjectiveFairShare,
+			@JsonProperty("weightObjectivePeakShaving") double weightObjectivePeakShaving,
+			@JsonProperty("weightObjectiveEnergyCosts") double weightObjectiveEnergyCosts,
+			@JsonProperty("weightObjectiveLoadImbalance") double weightObjectiveLoadImbalance
+			) {
+		this.weightObjectiveFairShare = weightObjectiveFairShare;
+		this.weightObjectivePeakShaving = weightObjectivePeakShaving;
+		this.weightObjectiveEnergyCosts = weightObjectiveEnergyCosts;
+		this.weightObjectiveLoadImbalance = weightObjectiveLoadImbalance;
+	}
+	
+	/**
+	 * Default settings are to only use fair share as the optimization goal.
+	 * @return
+	 */
+	public static OptimizerSettings getDefaultOptimizerSettings() {
+		OptimizerSettings settings = new OptimizerSettings();
+		settings.setWeightObjectiveFairShare(1);
+		settings.setWeightObjectiveEnergyCosts(0);
+		settings.setWeightObjectiveLoadImbalance(0);
+		settings.setWeightObjectivePeakShaving(0);
+		return settings;
+	}
+
+	public double getWeightObjectiveFairShare() {
+		return weightObjectiveFairShare;
+	}
+
+	public void setWeightObjectiveFairShare(double weightObjectiveFairShare) {
+		this.weightObjectiveFairShare = weightObjectiveFairShare;
+	}
+
+	public double getWeightObjectivePeakShaving() {
+		return weightObjectivePeakShaving;
+	}
+
+	public void setWeightObjectivePeakShaving(double weightObjectivePeakShaving) {
+		this.weightObjectivePeakShaving = weightObjectivePeakShaving;
+	}
+
+	public double getWeightObjectiveEnergyCosts() {
+		return weightObjectiveEnergyCosts;
+	}
+
+	public void setWeightObjectiveEnergyCosts(double weightObjectiveEnergyCosts) {
+		this.weightObjectiveEnergyCosts = weightObjectiveEnergyCosts;
+	}
+
+	public double getWeightObjectiveLoadImbalance() {
+		return weightObjectiveLoadImbalance;
+	}
+
+	public void setWeightObjectiveLoadImbalance(double weightObjectiveLoadImbalance) {
+		this.weightObjectiveLoadImbalance = weightObjectiveLoadImbalance;
+	}
+
+	@Override
+	public String toString() {
+		return "OptimizerSettings [weightObjectiveFairShare=" + weightObjectiveFairShare
+				+ ", weightObjectivePeakShaving=" + weightObjectivePeakShaving + ", weightObjectiveEnergyCosts="
+				+ weightObjectiveEnergyCosts + ", weightObjectiveLoadImbalance=" + weightObjectiveLoadImbalance + "]";
+	}
+
+}

--- a/src/main/java/com/sap/charging/server/api/v1/store/OptimizerSettings.java
+++ b/src/main/java/com/sap/charging/server/api/v1/store/OptimizerSettings.java
@@ -4,76 +4,76 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class OptimizerSettings {
-	
-	private double weightObjectiveFairShare;
-	private double weightObjectivePeakShaving;
-	private double weightObjectiveEnergyCosts;
-	private double weightObjectiveLoadImbalance;
-	
-	public OptimizerSettings() {}
-	
-	@JsonCreator
-	public OptimizerSettings(@JsonProperty("weightObjectiveFairShare") double weightObjectiveFairShare,
-			@JsonProperty("weightObjectivePeakShaving") double weightObjectivePeakShaving,
-			@JsonProperty("weightObjectiveEnergyCosts") double weightObjectiveEnergyCosts,
-			@JsonProperty("weightObjectiveLoadImbalance") double weightObjectiveLoadImbalance
-			) {
-		this.weightObjectiveFairShare = weightObjectiveFairShare;
-		this.weightObjectivePeakShaving = weightObjectivePeakShaving;
-		this.weightObjectiveEnergyCosts = weightObjectiveEnergyCosts;
-		this.weightObjectiveLoadImbalance = weightObjectiveLoadImbalance;
-	}
-	
-	/**
-	 * Default settings are to only use fair share as the optimization goal.
-	 * @return
-	 */
-	public static OptimizerSettings getDefaultOptimizerSettings() {
-		OptimizerSettings settings = new OptimizerSettings();
-		settings.setWeightObjectiveFairShare(1);
-		settings.setWeightObjectiveEnergyCosts(0);
-		settings.setWeightObjectiveLoadImbalance(0);
-		settings.setWeightObjectivePeakShaving(0);
-		return settings;
-	}
 
-	public double getWeightObjectiveFairShare() {
-		return weightObjectiveFairShare;
-	}
+    private double weightObjectiveFairShare;
+    private double weightObjectivePeakShaving;
+    private double weightObjectiveEnergyCosts;
+    private double weightObjectiveLoadImbalance;
 
-	public void setWeightObjectiveFairShare(double weightObjectiveFairShare) {
-		this.weightObjectiveFairShare = weightObjectiveFairShare;
-	}
+    public OptimizerSettings() {}
 
-	public double getWeightObjectivePeakShaving() {
-		return weightObjectivePeakShaving;
-	}
+    @JsonCreator
+    public OptimizerSettings(@JsonProperty("weightObjectiveFairShare") double weightObjectiveFairShare,
+        @JsonProperty("weightObjectivePeakShaving") double weightObjectivePeakShaving,
+        @JsonProperty("weightObjectiveEnergyCosts") double weightObjectiveEnergyCosts,
+        @JsonProperty("weightObjectiveLoadImbalance") double weightObjectiveLoadImbalance) {
+        this.weightObjectiveFairShare = weightObjectiveFairShare;
+        this.weightObjectivePeakShaving = weightObjectivePeakShaving;
+        this.weightObjectiveEnergyCosts = weightObjectiveEnergyCosts;
+        this.weightObjectiveLoadImbalance = weightObjectiveLoadImbalance;
+    }
 
-	public void setWeightObjectivePeakShaving(double weightObjectivePeakShaving) {
-		this.weightObjectivePeakShaving = weightObjectivePeakShaving;
-	}
+    /**
+     * Default settings are to only use fair share as the optimization goal.
+     * 
+     * @return
+     */
+    public static OptimizerSettings getDefaultOptimizerSettings() {
+        OptimizerSettings settings = new OptimizerSettings();
+        settings.setWeightObjectiveFairShare(1);
+        settings.setWeightObjectiveEnergyCosts(0);
+        settings.setWeightObjectiveLoadImbalance(0);
+        settings.setWeightObjectivePeakShaving(0);
+        return settings;
+    }
 
-	public double getWeightObjectiveEnergyCosts() {
-		return weightObjectiveEnergyCosts;
-	}
+    public double getWeightObjectiveFairShare() {
+        return weightObjectiveFairShare;
+    }
 
-	public void setWeightObjectiveEnergyCosts(double weightObjectiveEnergyCosts) {
-		this.weightObjectiveEnergyCosts = weightObjectiveEnergyCosts;
-	}
+    public void setWeightObjectiveFairShare(double weightObjectiveFairShare) {
+        this.weightObjectiveFairShare = weightObjectiveFairShare;
+    }
 
-	public double getWeightObjectiveLoadImbalance() {
-		return weightObjectiveLoadImbalance;
-	}
+    public double getWeightObjectivePeakShaving() {
+        return weightObjectivePeakShaving;
+    }
 
-	public void setWeightObjectiveLoadImbalance(double weightObjectiveLoadImbalance) {
-		this.weightObjectiveLoadImbalance = weightObjectiveLoadImbalance;
-	}
+    public void setWeightObjectivePeakShaving(double weightObjectivePeakShaving) {
+        this.weightObjectivePeakShaving = weightObjectivePeakShaving;
+    }
 
-	@Override
-	public String toString() {
-		return "OptimizerSettings [weightObjectiveFairShare=" + weightObjectiveFairShare
-				+ ", weightObjectivePeakShaving=" + weightObjectivePeakShaving + ", weightObjectiveEnergyCosts="
-				+ weightObjectiveEnergyCosts + ", weightObjectiveLoadImbalance=" + weightObjectiveLoadImbalance + "]";
-	}
+    public double getWeightObjectiveEnergyCosts() {
+        return weightObjectiveEnergyCosts;
+    }
+
+    public void setWeightObjectiveEnergyCosts(double weightObjectiveEnergyCosts) {
+        this.weightObjectiveEnergyCosts = weightObjectiveEnergyCosts;
+    }
+
+    public double getWeightObjectiveLoadImbalance() {
+        return weightObjectiveLoadImbalance;
+    }
+
+    public void setWeightObjectiveLoadImbalance(double weightObjectiveLoadImbalance) {
+        this.weightObjectiveLoadImbalance = weightObjectiveLoadImbalance;
+    }
+
+    @Override
+    public String toString() {
+        return "OptimizerSettings [weightObjectiveFairShare=" + weightObjectiveFairShare
+            + ", weightObjectivePeakShaving=" + weightObjectivePeakShaving + ", weightObjectiveEnergyCosts="
+            + weightObjectiveEnergyCosts + ", weightObjectiveLoadImbalance=" + weightObjectiveLoadImbalance + "]";
+    }
 
 }

--- a/src/test/java/com/sap/charging/server/EmobilitySmartChargingApplicationTests.java
+++ b/src/test/java/com/sap/charging/server/EmobilitySmartChargingApplicationTests.java
@@ -64,7 +64,7 @@ class EmobilitySmartChargingApplicationTests extends SimulationUnitTest {
 	}
 
 	@Test
-	void testRESTEndpoint_singleCarAssignment() throws URISyntaxException {
+	void testRestEndpoint_singleCarAssignment() throws URISyntaxException {
 		assertThat(controller).isNotNull();
 		
 		Car car = state.getCar(0); 
@@ -82,7 +82,7 @@ class EmobilitySmartChargingApplicationTests extends SimulationUnitTest {
 		
 		StateStore state = new StateStore(currentTimeSeconds, null, chargingStations, 100.0, dataSim.getCars(), dataSim.getEnergyPriceHistory(), carAssignments);
 		
-		OptimizeChargingProfilesRequest request = new OptimizeChargingProfilesRequest(state, event, 0); 
+		OptimizeChargingProfilesRequest request = new OptimizeChargingProfilesRequest(state, event, null, 0); 
 		
 		HttpHeaders headers = new HttpHeaders();
 		//headers.add("Authorization", "Basic dXNlcjE6QkU0a3BUWkhrQ3BNTVZqMzh6cGo=");
@@ -96,7 +96,6 @@ class EmobilitySmartChargingApplicationTests extends SimulationUnitTest {
 		// System.out.println("Testing POST request on uri=" + uri.toString());
 		
 		ResponseEntity<Object> response = this.restTemplate.postForEntity(uri, entity, Object.class); 
-		 
 
 		try {
 			OptimizeChargingProfilesResponse result = mapper.convertValue(response.getBody(), OptimizeChargingProfilesResponse.class); 
@@ -108,14 +107,8 @@ class EmobilitySmartChargingApplicationTests extends SimulationUnitTest {
 			
 		}
 		catch (Exception e) {
-			
-			//System.out.println("Response status: " + response.getStatusCodeValue());
-			//System.out.println(response.getBody());
-			
 			fail("REST Request failed."); 
 		}
-		
-		
 	}
 
 }

--- a/src/test/java/com/sap/charging/server/api/v1/OptimizeChargingProfilesControllerTest.java
+++ b/src/test/java/com/sap/charging/server/api/v1/OptimizeChargingProfilesControllerTest.java
@@ -1,0 +1,50 @@
+package com.sap.charging.server.api.v1;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import com.sap.charging.realTime.StrategyAlgorithmic;
+import com.sap.charging.realTime.util.TimeslotSortingCriteria;
+import com.sap.charging.server.api.v1.store.OptimizerSettings;
+
+
+@WebMvcTest(OptimizeChargingProfilesController.class)
+@ExtendWith(SpringExtension.class)
+class OptimizeChargingProfilesControllerTest {
+
+	private OptimizeChargingProfilesController classUnderTest; 
+
+	@BeforeEach
+	void setup() {
+		this.classUnderTest = new OptimizeChargingProfilesController();
+	}
+	
+	private static Stream<Arguments> buildStrategyValues() {
+        return Stream.of(
+            arguments("Default settings", OptimizerSettings.getDefaultOptimizerSettings(), TimeslotSortingCriteria.INDEX),
+            arguments("Empty settings with no weights", new OptimizerSettings(0, 0, 0, 0), TimeslotSortingCriteria.INDEX),
+            arguments("Settings with highest objective: fair share", new OptimizerSettings(1, 0, 0, 0), TimeslotSortingCriteria.INDEX),
+            arguments("Settings with highest objective: peak shaving", new OptimizerSettings(1, 10, 0, 0), TimeslotSortingCriteria.PEAK_DEMAND), 
+            arguments("Settings with highest objective: energy costs", new OptimizerSettings(1, 10, 100, 0), TimeslotSortingCriteria.PRICE));
+    }
+	
+	@ParameterizedTest
+	@MethodSource("buildStrategyValues")
+    @DisplayName("Build strategy based on incoming API request")
+	void buildStrategy(String name, OptimizerSettings settings, TimeslotSortingCriteria expectedSortingCritera) {
+		StrategyAlgorithmic strategy = (StrategyAlgorithmic) this.classUnderTest.buildStrategy(settings);
+		assertEquals(expectedSortingCritera, strategy.getSortingCriteriaByObjective());
+	}
+
+}

--- a/src/test/java/com/sap/charging/server/api/v1/OptimizeChargingProfilesControllerTest.java
+++ b/src/test/java/com/sap/charging/server/api/v1/OptimizeChargingProfilesControllerTest.java
@@ -23,28 +23,30 @@ import com.sap.charging.server.api.v1.store.OptimizerSettings;
 @ExtendWith(SpringExtension.class)
 class OptimizeChargingProfilesControllerTest {
 
-	private OptimizeChargingProfilesController classUnderTest; 
+    private OptimizeChargingProfilesController classUnderTest;
 
-	@BeforeEach
-	void setup() {
-		this.classUnderTest = new OptimizeChargingProfilesController();
-	}
-	
-	private static Stream<Arguments> buildStrategyValues() {
+    @BeforeEach
+    void setup() {
+        this.classUnderTest = new OptimizeChargingProfilesController();
+    }
+
+    private static Stream<Arguments> buildStrategyValues() {
         return Stream.of(
             arguments("Default settings", OptimizerSettings.getDefaultOptimizerSettings(), TimeslotSortingCriteria.INDEX),
             arguments("Empty settings with no weights", new OptimizerSettings(0, 0, 0, 0), TimeslotSortingCriteria.INDEX),
             arguments("Settings with highest objective: fair share", new OptimizerSettings(1, 0, 0, 0), TimeslotSortingCriteria.INDEX),
-            arguments("Settings with highest objective: peak shaving", new OptimizerSettings(1, 10, 0, 0), TimeslotSortingCriteria.PEAK_DEMAND), 
-            arguments("Settings with highest objective: energy costs", new OptimizerSettings(1, 10, 100, 0), TimeslotSortingCriteria.PRICE));
+            arguments("Settings with highest objective: peak shaving", new OptimizerSettings(1, 10, 0, 0),
+                TimeslotSortingCriteria.PEAK_DEMAND),
+            arguments("Settings with highest objective: energy costs", new OptimizerSettings(1, 10, 100, 0),
+                TimeslotSortingCriteria.PRICE));
     }
-	
-	@ParameterizedTest
-	@MethodSource("buildStrategyValues")
+
+    @ParameterizedTest
+    @MethodSource("buildStrategyValues")
     @DisplayName("Build strategy based on incoming API request")
-	void buildStrategy(String name, OptimizerSettings settings, TimeslotSortingCriteria expectedSortingCritera) {
-		StrategyAlgorithmic strategy = (StrategyAlgorithmic) this.classUnderTest.buildStrategy(settings);
-		assertEquals(expectedSortingCritera, strategy.getSortingCriteriaByObjective());
-	}
+    void buildStrategy(String name, OptimizerSettings settings, TimeslotSortingCriteria expectedSortingCritera) {
+        StrategyAlgorithmic strategy = (StrategyAlgorithmic) this.classUnderTest.buildStrategy(settings);
+        assertEquals(expectedSortingCritera, strategy.getSortingCriteriaByObjective());
+    }
 
 }

--- a/src/test/java/com/sap/charging/server/api/v1/store/OptimizerSettingsTest.java
+++ b/src/test/java/com/sap/charging/server/api/v1/store/OptimizerSettingsTest.java
@@ -1,0 +1,43 @@
+package com.sap.charging.server.api.v1.store;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.exc.ValueInstantiationException;
+
+class OptimizerSettingsTest {
+
+    private ObjectMapper objectMapper;
+
+    @BeforeEach
+    public void setup() {
+        this.objectMapper = new ObjectMapper();
+    }
+
+    private static Stream<Arguments> deserializeOptimizerSettingsValues() {
+        return Stream.of(
+            arguments("Null value", "{\"weightObjectiveFairShare\": null}", false),
+            arguments("Negative value", "{\"weightObjectiveFairShare\": -1}", true),
+            arguments("Valid JSON object (zero weight)", "{\"weightObjectiveFairShare\": 0}", false),
+            arguments("Valid JSON object (positive weight)", "{\"weightObjectiveFairShare\": 1}", false));
+    }
+
+    @ParameterizedTest
+    @MethodSource("deserializeOptimizerSettingsValues")
+    @DisplayName("Build strategy based on incoming API request")
+    void deserializeOptimizerSettings(String name, String json, boolean throwsException) {
+        if (throwsException) {
+            assertThrows(ValueInstantiationException.class, () -> objectMapper.readValue(json, OptimizerSettings.class));
+        } else {
+            assertDoesNotThrow(() -> objectMapper.readValue(json, OptimizerSettings.class));
+        }
+    }
+
+}


### PR DESCRIPTION
Peak shaving/energy price optimization can now be used via the REST API. See /swagger-ui.html for the documentation of the new request object. 