### PR TITLE
Fix potential flakiness in testToJSON

### DIFF
--- a/src/test/java/com/sap/charging/model/FuseTreeTest.java
+++ b/src/test/java/com/sap/charging/model/FuseTreeTest.java
@@ -124,12 +124,11 @@ public class FuseTreeTest {
 		FuseTree fuseTree = new FuseTree(root, 20);
 
 		JSONObject json1 = fuseTree.toJSONObject();
-		String jsonString1 = json1.toString();
 		
 		FuseTree clone = FuseTree.fromJSON(json1, new ArrayList<ChargingStation>());
-		String jsonString2 = clone.toJSONObject().toString();
+		JSONObject json2 = clone.toJSONObject();
 		
-		assertEquals(jsonString1, jsonString2);
+		assertEquals(json1, json2);
 	}
 	
 	


### PR DESCRIPTION
## The Issue

The original test calls `.toString()` for JSON objects, which may fall victim to the non-deterministic specification for a method that it calls implicitly.

## Reproduce

The plugin [NonDex](https://github.com/TestingResearchIllinois/NonDex) can be used to help identify code that relies on non-deterministic specifications. For instance, the following steps can be used to examine the test:

```
git clone https://github.com/SAP/emobility-smart-charging && cd emobility-smart-charging
mvn clean install -DskipTests
mvn edu.illinois:nondex-maven-plugin:1.1.2:nondex -Dtest=com.sap.charging.model.FuseTreeTest#testToJSON
```

Upon examination, HashMap Iterator was called implicitly during the process. And according to Java specification:

> Hash table based implementation of the Map interface. This implementation provides all of the optional map operations, and permits null values and the null key. (The HashMap class is roughly equivalent to Hashtable, except that it is unsynchronized and permits nulls.) **This class makes no guarantees as to the order of the map; in particular, it does not guarantee that the order will remain constant over time.**

## Solution

Instead of comparing the serialized string of these objects, it is safer to compare these objects directly. Or first serialize and then deserialize. And here the solution is to compare objects directly.

Please do comment on whether you think this fix is good, and give some advices if it's not, thank you :)